### PR TITLE
one line fix

### DIFF
--- a/src/controllers/forage_quality_census_controller.ts
+++ b/src/controllers/forage_quality_census_controller.ts
@@ -42,7 +42,7 @@ const getForageQualityCensuses: RequestHandler = async (req, res, next) => {
       rating,
       notes,
     });
-    res.status(200).json(forageQualityCensuses[0]);
+    res.status(200).json(forageQualityCensuses);
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
- Fix one line: `getForageQualityCensuses` now returns more than just `census[0]`

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
